### PR TITLE
fix: transposition cost calculation is off by 1 insertion / deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm test && npm run lint --fix"
+      "pre-push": "npm test && npm run lint"
     }
   }
 }

--- a/src/hermetrics/damerau_levenshtein.ts
+++ b/src/hermetrics/damerau_levenshtein.ts
@@ -28,7 +28,7 @@ class DamerauLevenshtein extends Levenshtein {
       distanceMatrix[0][j] = UPPER
     }
     for (let i = 1; i < rows; i++) {
-      distanceMatrix[i][1] = (i - 1) * insertCost
+      distanceMatrix[i][1] = (i - 1) * removeCost
     }
     for (let j = 1; j < cols; j++) {
       distanceMatrix[1][j] = (j - 1) * insertCost
@@ -60,7 +60,7 @@ class DamerauLevenshtein extends Levenshtein {
         substitution = distanceMatrix[i][j] + optSubCost
 
         transpotition = distanceMatrix[lastMatchRow][lastMatchCol] +
-                                Math.max((i - lastMatchRow) * removeCost, (j - lastMatchCol) * insertCost) + transposCost
+                        Math.max((i - lastMatchRow - 1) * removeCost, (j - lastMatchCol - 1) * insertCost) + transposCost
         distanceMatrix[i + 1][j + 1] = Math.min(deletion, insertion, substitution, transpotition)
 
         if (optSubCost === 0) {

--- a/tests/unit/damerau_levenshteinl.test.ts
+++ b/tests/unit/damerau_levenshteinl.test.ts
@@ -6,19 +6,35 @@ describe('Damerau - Levenshtein Distance', function()
 {
     describe('Distance Test', function()
     {
+        // 1 transposition
+        it('should return 2 for ab - ba', function()
+        {   
+            const dam = new DamerauLevenshtein();
+            const distance = dam.distance('ab', 'ba');
+            expect(distance).equal(1);
+        });
+        // 1 transposition and 1 deletion (unrestricted)
+        it('should return 2 for abc - ca', function()
+        {   
+            const dam = new DamerauLevenshtein();
+            const distance = dam.distance('abc', 'ca');
+            expect(distance).equal(2);
+        });
+        // 2 substitutions
         it('should return 2 for abcd - cbad', function()
         {   
             const dam = new DamerauLevenshtein();
             const distance = dam.distance('abcd', 'cbad');
             expect(distance).equal(2);
         });
-
+        // 2 insertions
         it('should return 2 for ace - abcde and (0.75, 1, 1.25, 1.5)', function()
         {   
             const dam = new DamerauLevenshtein();
             const distance = dam.distance('ace', 'abcde', {deletionCost:0.75, insertionCost:1,substitutionCost:1.25,transpositionCost:1.5});
             expect(distance).equal(2);
         });
+        // 3 substitutions
         it('should return 3 for abc - def', function()
         {   
             const dam = new DamerauLevenshtein();
@@ -29,37 +45,55 @@ describe('Damerau - Levenshtein Distance', function()
 
     describe('Similarity test', function()
     {
+        // 1 transposition and 1 deletion (unrestricted)
+        it('should return 0.3333 for abc - ca', function()
+        {   
+            const dam = new DamerauLevenshtein();
+            const similarity = dam.similarity('abc', 'ca');
+            const expApp = Math.abs(similarity - 0.3333) < ERROR;
+            expect(expApp).equal(true);
+        });
+        
         it('should return 0.5 for abcd - cbad', function()
         {   
             const dam = new DamerauLevenshtein();
             const similarity = dam.similarity('abcd', 'cbad');
-            const expApp = (0.5-ERROR < similarity && similarity < 0.5+ERROR) ? true : false
+            const expApp = Math.abs(similarity - 0.5) < ERROR;
             expect(expApp).equal(true);
         });
-
+        
         it('should return 0.6522 for ace - abcde and (0.75, 1, 1.25, 1.5)', function()
         {   
             const dam = new DamerauLevenshtein();
             const similarity = dam.similarity('ace', 'abcde', {deletionCost:0.75, insertionCost:1,substitutionCost:1.25,transpositionCost:1.5});
-            const expApp = (0.6522-ERROR < similarity && similarity < 0.6522+ERROR) ? true : false
+            const expApp = Math.abs(similarity - 0.6522) < ERROR;
             expect(expApp).equal(true);
         });
     })
     describe('Normalized test', function()
     {
+        // 1 transposition and 1 deletion (unrestricted)
+        it('should return 0.6667 for abc - ca', function()
+        {   
+            const dam = new DamerauLevenshtein();
+            const normalizedDistance = dam.normalizedDistance('abc', 'ca');
+            const expApp = Math.abs(normalizedDistance - 0.6667) < ERROR;
+            expect(expApp).equal(true);
+        });
+        
         it('should return 0.5 for abcd - cbad', function()
         {   
             const dam = new DamerauLevenshtein();
-            const similarity = dam.normalizedDistance('abcd', 'cbad');
-            const expApp = (0.5-ERROR < similarity && similarity < 0.5+ERROR) ? true : false
+            const normalizedDistance = dam.normalizedDistance('abcd', 'cbad');
+            const expApp = Math.abs(normalizedDistance - 0.5) < ERROR;
             expect(expApp).equal(true);
         });
-
+        
         it('should return 0.3478 for ace - abcde and (0.75, 1, 1.25, 1.5)', function()
         {   
             const dam = new DamerauLevenshtein();
-            const similarity = dam.normalizedDistance('ace', 'abcde', {deletionCost:0.75, insertionCost:1,substitutionCost:1.25,transpositionCost:1.5});
-            const expApp = (0.3478-ERROR < similarity && similarity < 0.3478+ERROR) ? true : false
+            const normalizedDistance = dam.normalizedDistance('ace', 'abcde', {deletionCost:0.75, insertionCost:1,substitutionCost:1.25,transpositionCost:1.5});
+            const expApp = Math.abs(normalizedDistance - 0.3478) < ERROR;
             expect(expApp).equal(true);
         });
     })

--- a/tests/unit/damerau_levenshteinl.test.ts
+++ b/tests/unit/damerau_levenshteinl.test.ts
@@ -61,7 +61,7 @@ describe('Damerau - Levenshtein Distance', function()
             const expApp = Math.abs(similarity - 0.5) < ERROR;
             expect(expApp).equal(true);
         });
-        
+
         it('should return 0.6522 for ace - abcde and (0.75, 1, 1.25, 1.5)', function()
         {   
             const dam = new DamerauLevenshtein();
@@ -88,7 +88,7 @@ describe('Damerau - Levenshtein Distance', function()
             const expApp = Math.abs(normalizedDistance - 0.5) < ERROR;
             expect(expApp).equal(true);
         });
-        
+
         it('should return 0.3478 for ace - abcde and (0.75, 1, 1.25, 1.5)', function()
         {   
             const dam = new DamerauLevenshtein();

--- a/tests/unit/damerau_levenshteinl.test.ts
+++ b/tests/unit/damerau_levenshteinl.test.ts
@@ -13,7 +13,7 @@ describe('Damerau - Levenshtein Distance', function()
             const distance = dam.distance('ab', 'ba');
             expect(distance).equal(1);
         });
-        // 1 transposition and 1 deletion (unrestricted)
+        // 1 deletion (b) then 1 transposition (ac -> ca) (unrestricted)
         it('should return 2 for abc - ca', function()
         {   
             const dam = new DamerauLevenshtein();
@@ -45,7 +45,7 @@ describe('Damerau - Levenshtein Distance', function()
 
     describe('Similarity test', function()
     {
-        // 1 transposition and 1 deletion (unrestricted)
+        // 1 deletion (b) then 1 transposition (ac -> ca) (unrestricted)
         it('should return 0.3333 for abc - ca', function()
         {   
             const dam = new DamerauLevenshtein();
@@ -72,7 +72,7 @@ describe('Damerau - Levenshtein Distance', function()
     })
     describe('Normalized test', function()
     {
-        // 1 transposition and 1 deletion (unrestricted)
+        // 1 deletion (b) then 1 transposition (ac -> ca) (unrestricted)
         it('should return 0.6667 for abc - ca', function()
         {   
             const dam = new DamerauLevenshtein();


### PR DESCRIPTION
- transposition calculation is off by 1 insertion/deletion:
    ```ts
    const { DamerauLevenshtein } = require("hermetrics");
    const dl = new DamerauLevenshtein();
    console.log(dl.distance("ab", "ba")); // outputs 2 instead of 1
    ```
    this is happening because the number of symbols that should be deleted / inserted is the number of symbols between the 2 elements that will be swapped, which is `(i - lastMatchRow - 1)` / `(j - lastMatchCol - 1)`, where `i` / `j` is the current symbol and `lastMatchRow` / `lastMatchCol` is the previous symbol to swap with current. (P.S., both `i`/`j` and `lastMatchRow`/`lastMatchCol` are off by 1 in the distanceMatrix, but it doesn't matter because we only want the number of symbols between them, and since they're both off by 1, we don't need to adjust).

- the first column should be populated with `removeCost` instead of `insertCost`.

- tests for damerau_levenshtein.ts don't have transposition testing, so I added 1 for basic transposition, and another for unrestricted transposition (to differentiate it from OSA).

- fixed some variable names in the tests, and shortened `expApp` from `(EXPECTED-ERROR < MEASURED && MEASURED < EXPECTED+ERROR)` to `Math.abs(MEASUERD - EXPECTED) < ERROR`

- pre-push hook command had an unnecessary `--fix` which already exists in the `lint` script